### PR TITLE
Add unit tests for cpac_config_extractor

### DIFF
--- a/src/gen192/cli.py
+++ b/src/gen192/cli.py
@@ -263,7 +263,7 @@ def generate_pipeline_from_combi(
 def main() -> None:
     """Main entry point for the CLI"""
 
-    checkout_sha=CPAC_SHA
+    checkout_sha = CPAC_SHA
     cpac_version_hash = b64_urlsafe_hash(checkout_sha)
 
     dir_dist = pl.Path("dist")

--- a/tests/test_cpac_config_extractor.py
+++ b/tests/test_cpac_config_extractor.py
@@ -83,6 +83,6 @@ class TestCheckCPACConfig:
         if (cpac_module_path := str(cpac_dir.absolute())) not in sys.path:
             sys.path.append(cpac_module_path)
 
-        ok, err = cpac_config_extractor.check_cpac_config("invalid")
+        ok, err = cpac_config_extractor.check_cpac_config("invalid")  # type: ignore [arg-type]
         assert not ok
         assert err is not None

--- a/tests/test_cpac_config_extractor.py
+++ b/tests/test_cpac_config_extractor.py
@@ -7,7 +7,7 @@ from typing import Generator
 import pytest
 
 from gen192 import cpac_config_extractor, utils
-from gen192.cli import PIPELINE_NAMES
+from gen192.cli import PIPELINE_NAMES, load_pipeline_config
 
 
 class TestDownloadCPACRepo:
@@ -52,10 +52,25 @@ class TestFetchAndExpandCPACConfig:
 
 class TestCheckCPACConfig:
     def test_check_valid_config(self, tmp_path: pl.Path) -> None:
-        ...
+        cpac_dir = tmp_path / "cpac_source"
+        output_dir = tmp_path / "cpac_configs"
+
+        # Create configs
+        cpac_config_extractor.fetch_and_expand_cpac_configs(
+            cpac_dir=cpac_dir,
+            output_dir=output_dir,
+            checkout_sha="main",
+            config_names_ids=PIPELINE_NAMES,
+        )
+
+        for pipeline_name in PIPELINE_NAMES:
+            pipeline = load_pipeline_config(output_dir / (utils.filesafe(pipeline_name) + ".yml"))
+            valid, msg = cpac_config_extractor.check_cpac_config(pipeline.config)
+            assert valid
+            assert msg is None
 
     def test_check_invalid_config(self, tmp_path: pl.Path) -> None:
-        # Temporary block to install CPAC if it does not already exist
+        # Temporary installation of CPAC package if it does not already exist
         cpac_dir = tmp_path / "cpac_source"
         output_dir = tmp_path / "cpac_configs"
 

--- a/tests/test_cpac_config_extractor.py
+++ b/tests/test_cpac_config_extractor.py
@@ -8,6 +8,7 @@ import pytest
 
 from gen192 import cpac_config_extractor, utils
 from gen192.cli import PIPELINE_NAMES, load_pipeline_config
+from gen192.config import CPAC_SHA
 
 
 class TestDownloadCPACRepo:
@@ -26,7 +27,7 @@ class TestDownloadCPACRepo:
         assert cmd_exit.value.code == 1
 
     def test_download_cpac_repo_valid(self, tmp_path: pl.Path) -> None:
-        cpac_config_extractor._download_cpac_repo(cpac_dir=tmp_path, checkout_sha="main")
+        cpac_config_extractor._download_cpac_repo(cpac_dir=tmp_path, checkout_sha=CPAC_SHA)
         assert os.path.exists(f"{tmp_path}/CPAC")
 
 
@@ -38,7 +39,7 @@ class TestFetchAndExpandCPACConfig:
         cpac_config_extractor.fetch_and_expand_cpac_configs(
             cpac_dir=cpac_dir,
             output_dir=output_dir,
-            checkout_sha="main",
+            checkout_sha=CPAC_SHA,
             config_names_ids=PIPELINE_NAMES,
         )
 
@@ -59,7 +60,7 @@ class TestCheckCPACConfig:
         cpac_config_extractor.fetch_and_expand_cpac_configs(
             cpac_dir=cpac_dir,
             output_dir=output_dir,
-            checkout_sha="main",
+            checkout_sha=CPAC_SHA,
             config_names_ids=PIPELINE_NAMES,
         )
 
@@ -76,7 +77,7 @@ class TestCheckCPACConfig:
 
         if not (cpac_dir / "CPAC").exists():
             cpac_dir.mkdir(parents=True, exist_ok=True)
-            cpac_config_extractor._download_cpac_repo(cpac_dir=cpac_dir, checkout_sha="main")
+            cpac_config_extractor._download_cpac_repo(cpac_dir=cpac_dir, checkout_sha=CPAC_SHA)
 
         output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_cpac_config_extractor.py
+++ b/tests/test_cpac_config_extractor.py
@@ -1,6 +1,7 @@
 """Test gen192.cpac_config_extractor"""
 import os
 import pathlib as pl
+import sys
 from typing import Generator
 
 import pytest
@@ -47,3 +48,26 @@ class TestFetchAndExpandCPACConfig:
         assert os.path.exists(output_dir)
         for config_name in PIPELINE_NAMES:
             assert os.path.exists(output_dir / (utils.filesafe(config_name) + ".yml"))
+
+
+class TestCheckCPACConfig:
+    def test_check_valid_config(self, tmp_path: pl.Path) -> None:
+        ...
+
+    def test_check_invalid_config(self, tmp_path: pl.Path) -> None:
+        # Temporary block to install CPAC if it does not already exist
+        cpac_dir = tmp_path / "cpac_source"
+        output_dir = tmp_path / "cpac_configs"
+
+        if not (cpac_dir / "CPAC").exists():
+            cpac_dir.mkdir(parents=True, exist_ok=True)
+            cpac_config_extractor._download_cpac_repo(cpac_dir=cpac_dir, checkout_sha="main")
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        if (cpac_module_path := str(cpac_dir.absolute())) not in sys.path:
+            sys.path.append(cpac_module_path)
+
+        ok, err = cpac_config_extractor.check_cpac_config("invalid")
+        assert not ok
+        assert err is not None

--- a/tests/test_cpac_config_extractor.py
+++ b/tests/test_cpac_config_extractor.py
@@ -5,7 +5,8 @@ from typing import Generator
 
 import pytest
 
-from gen192 import cpac_config_extractor
+from gen192 import cpac_config_extractor, utils
+from gen192.cli import PIPELINE_NAMES
 
 
 class TestDownloadCPACRepo:
@@ -26,3 +27,23 @@ class TestDownloadCPACRepo:
     def test_download_cpac_repo_valid(self, tmp_path: pl.Path) -> None:
         cpac_config_extractor._download_cpac_repo(cpac_dir=tmp_path, checkout_sha="main")
         assert os.path.exists(f"{tmp_path}/CPAC")
+
+
+class TestFetchAndExpandCPACConfig:
+    def test_fetch_and_expand(self, tmp_path: pl.Path) -> None:
+        cpac_dir = tmp_path / "cpac_source"
+        output_dir = tmp_path / "cpac_configs"
+
+        cpac_config_extractor.fetch_and_expand_cpac_configs(
+            cpac_dir=cpac_dir,
+            output_dir=output_dir,
+            checkout_sha="main",
+            config_names_ids=PIPELINE_NAMES,
+        )
+
+        assert os.path.exists(cpac_dir)
+
+        # Check output configurations exist and correctly named
+        assert os.path.exists(output_dir)
+        for config_name in PIPELINE_NAMES:
+            assert os.path.exists(output_dir / (utils.filesafe(config_name) + ".yml"))

--- a/tests/test_cpac_config_extractor.py
+++ b/tests/test_cpac_config_extractor.py
@@ -1,0 +1,28 @@
+"""Test gen192.cpac_config_extractor"""
+import os
+import pathlib as pl
+from typing import Generator
+
+import pytest
+
+from gen192 import cpac_config_extractor
+
+
+class TestDownloadCPACRepo:
+    def test_download_cpac_repo_fail(
+        self,
+        capsys: Generator[pytest.CaptureFixture[str], None, None],
+        tmp_path: pl.Path,
+        checkout_sha: str = "invalid",
+    ) -> None:
+        with pytest.raises(SystemExit) as cmd_exit:
+            cpac_config_extractor._download_cpac_repo(cpac_dir=tmp_path, checkout_sha=checkout_sha)
+            captured = capsys.readouterr().out  # type: ignore
+            assert "Could not checkout" in captured
+
+        assert cmd_exit.type == SystemExit
+        assert cmd_exit.value.code == 1
+
+    def test_download_cpac_repo_valid(self, tmp_path: pl.Path) -> None:
+        cpac_config_extractor._download_cpac_repo(cpac_dir=tmp_path, checkout_sha="main")
+        assert os.path.exists(f"{tmp_path}/CPAC")


### PR DESCRIPTION
Added generic unit tests to test functionality of `gen192.cpac_config_extractor`. These tests can take slightly longer to run because of the need to clone the repository. Also in some discussions earlier, noted that we might want to move the `checkout_sha` to a global variable, which also make it easily accessible to the tests.

Some of these test may be a little cyclic. I get the gist of what is happening here, but I wasn't sure of all of the behind-the-scenes things yet, so rather than try to write something new in the tests. I made use of the existing functionality (e.g. using `multi_get` when testing `multi_set`). 

One minor note here is that C-PAC module installation is assumed to be installed in `check_cpac_config` call, which may work in the actual workflow, but would cause the unit test to fail. For now I've added a temporary check + install in the test, but will refactor the module in a later PR to drop this assumption.

_Will address the codecov `cli.py` issue when I tackle the unit tests there._