### PR TITLE
Add unit tests for cli.py

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -939,6 +939,23 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1401,4 +1418,4 @@ pyyaml = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c355353452b0cccb75901af328dce2b92d280cba4bb92854d3adb2d084360445"
+content-hash = "05856a8223aa31ae9b0d6c7bb3f8399f7dd12b5aeb60ef47c3bc824761e5df2e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ pre-commit = "^3.6.2"
 pytest-cov = "^4.1.0"
 ruff = "^0.3.0"
 types-pyyaml = "^6.0.12.11"
+pytest-mock = "^3.14.0"
 
 [tool.poetry.group.docs.dependencies]
 pdoc = "^14.4.0"

--- a/src/gen192/cli.py
+++ b/src/gen192/cli.py
@@ -9,7 +9,15 @@ import yaml
 
 from .config import CPAC_SHA
 from .cpac_config_extractor import check_cpac_config, fetch_and_expand_cpac_configs
-from .utils import aslist, b64_urlsafe_hash, filesafe, multi_del, multi_get, multi_set, print_warning
+from .utils import (
+    aslist,
+    b64_urlsafe_hash,
+    filesafe,
+    multi_del,
+    multi_get,
+    multi_set,
+    print_warning,
+)
 
 PIPELINE_NAMES = {
     "ABCD": "abcd-options",
@@ -50,7 +58,11 @@ PIPELINE_STEPS: List[PipelineStep] = [
         name="Functional Masking",
         merge_paths=[
             ["functional_preproc", "func_masking"],
-            ["registration_workflows", "anatomical_registration", "T1w_brain_template_mask"],
+            [
+                "registration_workflows",
+                "anatomical_registration",
+                "T1w_brain_template_mask",
+            ],
             [
                 "registration_workflows",
                 "functional_registration",
@@ -193,7 +205,7 @@ def generate_pipeline_from_combi(
         snippet_target = multi_get(pipeline.config, index=merge_path)
 
         if snippet is None:
-            warning = f"Cant find path {merge_path} in {pipeline_perturb.name}"
+            warning = f"Can't find path {merge_path} in {pipeline_perturb.name}"
             pipeline.notes = pipeline.notes + "\n" + warning if pipeline.notes else warning
             print_warning(warning)
             multi_del(pipeline.config, index=merge_path)

--- a/src/gen192/cli.py
+++ b/src/gen192/cli.py
@@ -99,8 +99,11 @@ class PipelineConfig:
         self.name = name
         self.config["pipeline_setup"]["pipeline_name"] = name
 
+    def _file_exists(self) -> bool:
+        return self.file.exists()
+
     def dump(self, exist_ok: bool = False) -> None:
-        if self.file.exists() and not exist_ok:
+        if self._file_exists() and not exist_ok:
             raise FileExistsError(f"File {self.file} already exists")
         with open(self.file, "w") as handle:
             yaml.dump(self.config, handle)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+import pathlib as pl
+import shutil
+import tempfile
+import zipfile
+from urllib import request
+
+import pytest
+import yaml
+
+from gen192.cli import PipelineConfig
+
+
+@pytest.fixture
+def test_config() -> PipelineConfig:
+    """Download and load configuration for test suite without relying on created
+    methods"""
+    test_config = "abcd.yml"
+    zip_fname = "cpac_source_configs_RlrTzPGDmrVjfNbBigtDGkfRmp0.zip"
+    config_url = f"https://github.com/childmindresearch/gen192/releases/download/dev/{zip_fname}"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with request.urlopen(config_url) as response, open((zip_fpath := f"{temp_dir}/{zip_fname}"), "wb") as out_zip:
+            shutil.copyfileobj(response, out_zip)
+
+        with zipfile.ZipFile(zip_fpath) as zip_file:
+            zip_file.extractall(temp_dir)
+
+        with open((test_config_path := f"{temp_dir}/{test_config}"), "r") as handle:
+            test_config = yaml.safe_load(handle)
+
+    return PipelineConfig(
+        name=test_config["pipeline_setup"]["pipeline_name"],  # type: ignore [index]
+        file=pl.Path(test_config_path),
+        config=test_config,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,19 +14,22 @@ from gen192.cli import PipelineConfig
 def test_config() -> PipelineConfig:
     """Download and load configuration for test suite without relying on created
     methods"""
-    test_config = "abcd.yml"
+    test_config_fname = "abcd.yml"
     zip_fname = "cpac_source_configs_RlrTzPGDmrVjfNbBigtDGkfRmp0.zip"
     config_url = f"https://github.com/childmindresearch/gen192/releases/download/dev/{zip_fname}"
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        with request.urlopen(config_url) as response, open((zip_fpath := f"{temp_dir}/{zip_fname}"), "wb") as out_zip:
+        with (
+            request.urlopen(config_url) as response,
+            open((zip_fpath := f"{temp_dir}/{zip_fname}"), "wb") as out_zip,
+        ):
             shutil.copyfileobj(response, out_zip)
 
         with zipfile.ZipFile(zip_fpath) as zip_file:
             zip_file.extractall(temp_dir)
 
-        with open((test_config_path := f"{temp_dir}/{test_config}"), "r") as handle:
-            test_config = yaml.safe_load(handle)
+        with open((test_config_path := f"{temp_dir}/{test_config_fname}"), "r") as handle:
+            test_config: dict = yaml.safe_load(handle)
 
     return PipelineConfig(
         name=test_config["pipeline_setup"]["pipeline_name"],  # type: ignore [index]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,7 +141,17 @@ class TestIterPipelineCombis:
         assert len(actual_combis) < expected_combis
 
 
-class TestLoadPipelineConfig: ...
+class TestLoadPipelineConfig:
+    def test_load_pipeline_config(self, test_config: cli.PipelineConfig) -> None:
+        with tempfile.NamedTemporaryFile() as tmp_file:
+            test_config.file = pl.Path(tmp_file.name)
+            test_config.dump(exist_ok=True)
+
+            new_config = cli.load_pipeline_config(pl.Path(tmp_file.name))
+            assert isinstance(new_config, cli.PipelineConfig)
+            assert new_config.name == test_config.name
+            assert new_config.file == test_config.file
+            assert new_config.config == test_config.config
 
 
 class TestGeneratePipelineFromCombi: ...

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,78 @@
+"""Test gen192.cli"""
+
+import os
+import pathlib as pl
+import tempfile
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+import gen192.cli as cli
+
+
+class TestPipelineConfig:
+    @pytest.mark.parametrize("notes", [(None), ("hello world")])
+    def test_init_class(self, tmp_path: pl.Path, notes: str | None) -> None:
+        pipeline_inputs: list[Any] = ["pipeline_config", tmp_path, {}, notes]
+        pipeline_cfg = cli.PipelineConfig(*pipeline_inputs)
+        assert isinstance(pipeline_cfg, cli.PipelineConfig)
+
+        for idx, (cfg_input, cfg_type) in enumerate(
+            zip(
+                pipeline_cfg.__dict__.values(),
+                [str, pl.Path, dict, str | None],
+            )
+        ):
+            assert isinstance(cfg_input, cfg_type)  # type: ignore [arg-type]
+            assert cfg_input == pipeline_inputs[idx]
+
+    def test_clone(self, test_config: cli.PipelineConfig) -> None:
+        pipeline_cfg = test_config.clone()
+
+        assert pipeline_cfg == test_config
+
+    def test_set_name(self, test_config: cli.PipelineConfig, new_name: str = "RandomPipeline") -> None:
+        # Set up test pipeline config
+        test_config.set_name(new_name)
+        assert test_config.name == new_name
+        assert test_config.config["pipeline_setup"]["pipeline_name"] == new_name
+
+    def test_dump_file_exists_error(self, test_config: cli.PipelineConfig, mocker: MockerFixture) -> None:
+        mocker.patch.object(
+            test_config,
+            "dump",
+            side_effect=FileExistsError(f"File {test_config.file} already exists"),
+        )
+        with pytest.raises(FileExistsError, match="already exists"):
+            test_config.dump(exist_ok=False)
+
+    @pytest.mark.parametrize("exist_ok", [(True), (False)])
+    def test_dump_file_valid(self, test_config: cli.PipelineConfig, exist_ok: bool) -> None:
+        with tempfile.NamedTemporaryFile() as out_file:
+            if not exist_ok:
+                os.remove(out_file.name)
+            test_config.file = pl.Path(out_file.name)
+            test_config.dump(exist_ok=exist_ok)
+
+            assert os.path.exists(out_file.name)
+
+
+class TestPipelineCombination: ...
+
+
+class TestIterPipelineCombis:
+    # Combine both "all" and "no_duplicate" testing here
+    # TODO: refactor into single function
+    ...
+
+
+class TestLoadPipelineConfig: ...
+
+
+class TestGeneratePipelineFromCombi: ...
+
+
+class TestMain:
+    # Test for entry point / end-to-end run
+    ...

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Test gen192.cli"""
 
+import itertools as it
 import os
 import pathlib as pl
 import random
@@ -107,9 +108,29 @@ class TestPipelineCombination:
 
 
 class TestIterPipelineCombis:
-    # Combine both "all" and "no_duplicate" testing here
-    # TODO: refactor into single function
-    ...
+    @pytest.fixture
+    def expected_combis(self) -> int:
+        return len(
+            list(
+                it.product(
+                    cli.PIPELINE_NAMES,
+                    cli.PIPELINE_NAMES,
+                    cli.PIPELINE_STEPS,
+                    cli.CONNECTIVITY_METHODS,
+                    cli.NUISANCE_METHODS,
+                )
+            )
+        )
+
+    def test_iter_all_combis(self, expected_combis: int) -> None:
+        actual_combis = list(cli.iter_pipeline_combis())
+
+        assert len(actual_combis) == expected_combis
+
+    def test_iter_no_duplicates(self, expected_combis: int) -> None:
+        actual_combis = list(cli.iter_pipeline_combis_no_duplicates())
+
+        assert len(actual_combis) < expected_combis
 
 
 class TestLoadPipelineConfig: ...

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,13 +43,10 @@ class TestPipelineConfig:
         assert test_config.config["pipeline_setup"]["pipeline_name"] == new_name
 
     def test_dump_file_exists_error(self, test_config: cli.PipelineConfig, mocker: MockerFixture) -> None:
-        mocker.patch.object(
-            test_config,
-            "dump",
-            side_effect=FileExistsError(f"File {test_config.file} already exists"),
-        )
-        with pytest.raises(FileExistsError, match="already exists"):
-            test_config.dump(exist_ok=False)
+        with mocker.patch("builtins.open", side_effect=FileExistsError("File already exists")):
+            mocker.patch.object(test_config, "_file_exists", return_value=True)
+            with pytest.raises(FileExistsError, match="already exists"):
+                test_config.dump(exist_ok=False)
 
     @pytest.mark.parametrize("exist_ok", [(True), (False)])
     def test_dump_file_valid(self, test_config: cli.PipelineConfig, exist_ok: bool) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import itertools as it
 import os
 import pathlib as pl
 import random
+import shutil
 import tempfile
 from typing import Any, Generator
 
@@ -108,7 +109,7 @@ class TestPipelineCombination:
         pipeline_num = random.randint(1, 192)
         test_fname = test_combi.filename(pipeline_num)
 
-        assert test_fname == f"p{pipeline_num:03d}_{test_combi_name}"
+        assert test_fname == f"p{pipeline_num:03d}_{test_combi_name}.yml"
         assert isinstance(test_fname, str)
 
 
@@ -157,7 +158,7 @@ def test_configs(test_config: cli.PipelineConfig) -> cli.ConfigLookupTable:
 
 
 class TestGeneratePipelineFromCombi:
-    def test_generate_pipeline_w_warnings(
+    def test_generate_pipeline_from_combi_w_warnings(
         self,
         test_combi: cli.PipelineCombination,
         test_configs: cli.ConfigLookupTable,
@@ -177,5 +178,17 @@ class TestGeneratePipelineFromCombi:
 
 
 class TestMain:
-    # Test for entry point / end-to-end run
-    ...
+    def test_main(self, capsys: Generator[pytest.CaptureFixture[str], None, None]) -> None:
+        # Remove existing distribution dirs for testing
+        if os.path.exists("build"):
+            shutil.rmtree("build")
+        cli.main()
+        captured = capsys.readouterr().out  # type: ignore
+        for msg in [
+            "Loaded pipeline",
+            "Generating base pipeline",
+            "Generated pipeline",
+            "Generating 192 permutations",
+            "> Generating",
+        ]:
+            assert msg in captured

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import os
 import pathlib as pl
 import random
 import tempfile
-from typing import Any
+from typing import Any, Generator
 
 import pytest
 from pytest_mock import MockerFixture
@@ -149,6 +149,31 @@ class TestLoadPipelineConfig:
             assert new_config.name == test_config.name
             assert new_config.file == test_config.file
             assert new_config.config == test_config.config
+
+
+@pytest.fixture
+def test_configs(test_config: cli.PipelineConfig) -> cli.ConfigLookupTable:
+    return {"1": test_config, "2": test_config}
+
+
+class TestGeneratePipelineFromCombi:
+    def test_generate_pipeline_w_warnings(
+        self,
+        test_combi: cli.PipelineCombination,
+        test_configs: cli.ConfigLookupTable,
+        capsys: Generator[pytest.CaptureFixture[str], None, None],
+    ) -> None:
+        # Change merge path in one config to
+        pipeline = cli.generate_pipeline_from_combi(
+            1,
+            combi=test_combi,
+            configs=test_configs,
+        )
+        captured = capsys.readouterr().out  # type: ignore
+        assert "Can't find path" in captured
+        assert "identical to target" in captured
+
+        assert isinstance(pipeline, cli.PipelineConfig)
 
 
 class TestMain:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,14 @@ class TestPipelineConfig:
 
             assert os.path.exists(out_file.name)
 
+    def test_dump_notes(self, test_config: cli.PipelineConfig) -> None:
+        test_config.notes = "Hello world"
+        with tempfile.NamedTemporaryFile() as out_file:
+            test_config.file = pl.Path(out_file.name)
+            test_config.dump(exist_ok=True)
+
+        assert os.path.exists(f"{test_config.file}.notes.txt")
+
 
 class TestPipelineCombination:
     @pytest.fixture()


### PR DESCRIPTION
Added generic unit tests to test functionality of `gen192.cli`. The tests for `main` and `generate_pipeline_from_combi` could probably be improved further, but for now, these will test the basic functionality. I've also added the `pytest-mock` library to the dev dependencies, using it to help raise a `FileExistsError`. In the same tested function, also made a slight refactor so that mocking is possible.

Further, added a `conftest.py` to set up and make available globally during the testing the configs in the dev tag / release.

I think the `cli.py` can maybe be refactored a little bit, moving dataclasses and types to its own `.py` files. - but can discuss and tackle it in a later PR if needed.