### PR TITLE
Fix deprecated SPDX license identifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 authors = [
   {name = "CMI DAIR", email = "dair@childmind.org"}
 ]
-license = "LGPL-2.1"
+license = "LGPL-2.1-only"
 requires-python = ">=3.10"
 name = "gen192"
 version = "0.1.0"


### PR DESCRIPTION
Updates deprecated SPDX license identifiers to fix build failures.

- `LGPL-2.1` → `LGPL-2.1-only`